### PR TITLE
feat: ExpenseControllerの実装

### DIFF
--- a/app/finance-api/build.gradle.kts
+++ b/app/finance-api/build.gradle.kts
@@ -51,6 +51,8 @@ tasks.compileJava {
 
 dependencies {
 	implementation("org.openapitools:jackson-databind-nullable:0.2.6")
+	implementation("io.swagger.core.v3:swagger-annotations:2.2.22")
+	implementation("jakarta.validation:jakarta.validation-api:3.1.0")
 	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-webmvc")

--- a/app/finance-api/src/main/java/com/example/finance_api/controller/ExpenseController.java
+++ b/app/finance-api/src/main/java/com/example/finance_api/controller/ExpenseController.java
@@ -1,0 +1,37 @@
+package com.example.finance_api.controller;
+
+import com.example.finance_api.api.DefaultApi;
+import com.example.finance_api.model.ExpenseListResponse;
+import com.example.finance_api.model.ExpenseSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ExpenseController implements DefaultApi {
+
+    @Override
+    public ResponseEntity<ExpenseListResponse> apiExpensesGet(Integer year, Integer month) {
+        // TODO: BigQueryからデータを取得する
+        var response = new ExpenseListResponse()
+                .year(year)
+                .month(month)
+                .total(0)
+                .expenses(List.of());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<ExpenseSummaryResponse> apiExpensesSummaryGet(Integer year, Integer month) {
+        // TODO: BigQueryからデータを取得する
+        var response = new ExpenseSummaryResponse()
+                .year(year)
+                .month(month)
+                .total(0)
+                .categories(List.of());
+        return ResponseEntity.ok(response);
+    }
+}


### PR DESCRIPTION
## 概要

Issue #2 の実装です。

## 変更内容

- `ExpenseController` を新規作成
  - `DefaultApi` インターフェースを実装
  - `/api/expenses` と `/api/expenses/summary` エンドポイントを提供
  - スタブレスポンスを返す実装（BigQuery連携はTODOとしてコメント残し）

- `build.gradle.kts` に依存関係を追加
  - `swagger-annotations` (OpenAPIアノテーション用)
  - `jakarta.validation-api` (バリデーションアノテーション用)

## 動作確認

```bash
./gradlew build  # ビルド成功
```

## エンドポイント

- `GET /api/expenses?year=2026&month=3` - 支出一覧（スタブ）
- `GET /api/expenses/summary?year=2026&month=3` - カテゴリ別集計（スタブ）

## 補足

BigQueryからの実データ取得は別途実装予定。