### PR TITLE
feat: APIキー認証の実装 (SecurityConfig)

### DIFF
--- a/app/finance-api/src/main/java/com/example/finance_api/config/ApiKeyAuthFilter.java
+++ b/app/finance-api/src/main/java/com/example/finance_api/config/ApiKeyAuthFilter.java
@@ -1,0 +1,39 @@
+package com.example.finance_api.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+    private final String apiKey;
+
+    public ApiKeyAuthFilter(@Value("${api.key}") String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String key = request.getHeader("X-API-Key");
+        if (apiKey.equals(key)) {
+            UsernamePasswordAuthenticationToken auth =
+                    new UsernamePasswordAuthenticationToken("api", null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            filterChain.doFilter(request, response);
+        } else {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid API Key");
+        }
+    }
+}

--- a/app/finance-api/src/main/java/com/example/finance_api/config/SecurityConfig.java
+++ b/app/finance-api/src/main/java/com/example/finance_api/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.example.finance_api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                    ApiKeyAuthFilter apiKeyAuthFilter) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .httpBasic(basic -> basic.disable())
+            .formLogin(form -> form.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/app/finance-api/src/main/resources/application.yaml
+++ b/app/finance-api/src/main/resources/application.yaml
@@ -4,3 +4,6 @@ spring:
 
 bigquery:
   project-id: ${BIGQUERY_PROJECT_ID}
+
+api:
+  key: ${API_KEY}

--- a/app/finance-api/src/test/resources/application.yaml
+++ b/app/finance-api/src/test/resources/application.yaml
@@ -1,2 +1,5 @@
 bigquery:
   project-id: test-project
+
+api:
+  key: test-api-key


### PR DESCRIPTION
## 概要

Issue #10 の実装です。

## 変更内容

### 新規作成
- **ApiKeyAuthFilter**: X-API-Keyヘッダーによる認証フィルター
  - OncePerRequestFilterを継承
  - ヘッダー値と設定値を比較
  - 一致時はSecurityContextに認証情報をセット
  - 不一致時は401 Unauthorizedを返却

- **SecurityConfig**: APIキー認証のセキュリティ設定
  - @EnableWebSecurityで有効化
  - CSRF無効化（REST APIのため）
  - HTTP Basic/フォームログイン無効化
  - 全リクエストに認証を要求
  - ApiKeyAuthFilterをUsernamePasswordAuthenticationFilterの前に追加

### 更新
- **application.yaml**: APIキー設定を追加（環境変数から読み込み）
- **application.yaml (test)**: テスト用APIキー設定

## 動作確認

```bash
./gradlew build  # ビルド成功
```

## 使用方法

リクエスト時に `X-API-Key` ヘッダーにAPIキーを設定：



## 補足

- APIキーの実際の値は環境変数 `API_KEY` として外から渡す想定
- 無効なキーまたはヘッダーなしの場合は401 Unauthorized

Closes #10